### PR TITLE
[feat] - 태그 UI 추가

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,7 +37,6 @@ const MainPage = () => {
         <Tag size="small" color="gray">
           TAG
         </Tag>
-
         <Tag size="small" color="yellow">
           TAG
         </Tag>
@@ -51,6 +50,26 @@ const MainPage = () => {
           TAG
         </Tag>
         <Tag size="small" color="red">
+          진짜진짜긴태그
+        </Tag>
+      </div>
+      <div className="flex w-200 gap-1">
+        <Tag size="big" color="gray">
+          TAG
+        </Tag>
+        <Tag size="big" color="yellow">
+          TAG
+        </Tag>
+        <Tag size="big" color="blue">
+          TAG
+        </Tag>
+        <Tag size="big" color="green">
+          TAG
+        </Tag>
+        <Tag size="big" color="purple">
+          TAG
+        </Tag>
+        <Tag size="big" color="red">
           진짜진짜긴태그
         </Tag>
       </div>

--- a/components/common/Tag.tsx
+++ b/components/common/Tag.tsx
@@ -1,22 +1,41 @@
+import { TAG_VARIANTS, TagColor } from "@/constants/Tag.style";
+import { twMerge } from "tailwind-merge";
+
 const Tag = ({
   size = "small",
   color,
   children,
+  className,
 }: {
   size: "small" | "big";
-  color: "blue" | "red" | "gray" | "yellow" | "green" | "purple";
+  color: TagColor;
   children: string;
+  className?: string;
 }) => {
   return (
     <>
       {size === "small" && (
         <span
-          className={`h-fit px-2 text-tag-text-${color} bg-tag-bg-${color} c2 rounded-3xl text-center`}
+          className={twMerge(
+            "c2 h-fit min-h-5 rounded-3xl px-2 text-center",
+            TAG_VARIANTS[color],
+            className,
+          )}
         >
           {children}
         </span>
       )}
-      {size === "big" && <span className="h-6 px-4">{children}</span>}
+      {size === "big" && (
+        <span
+          className={twMerge(
+            "c2 h-fit min-h-6 min-w-16 rounded-3xl px-4 text-center",
+            TAG_VARIANTS[color],
+            className,
+          )}
+        >
+          {children}
+        </span>
+      )}
     </>
   );
 };

--- a/constants/Tag.style.ts
+++ b/constants/Tag.style.ts
@@ -1,0 +1,10 @@
+export const TAG_VARIANTS = {
+  blue: "text-tag-text-blue bg-tag-bg-blue",
+  red: "text-tag-text-red bg-tag-bg-red",
+  gray: "text-tag-text-gray bg-tag-bg-gray",
+  yellow: "text-tag-text-yellow bg-tag-bg-yellow",
+  green: "text-tag-text-green bg-tag-bg-green",
+  purple: "text-tag-text-purple bg-tag-bg-purple",
+} as const;
+
+export type TagColor = keyof typeof TAG_VARIANTS;


### PR DESCRIPTION
## #️⃣ Issue Number

#4 태그 UI 추가

## 📝 요약(Summary)

작은 태그, 큰 태그 컴포넌트 추가

## 🛠️ PR 유형

태그 컴포넌트를 추가하여, size, color를 props로 받아 사용할 수 있습니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

<img width="589" height="81" alt="image" src="https://github.com/user-attachments/assets/be173364-3465-4400-8b05-dcdc377eba25" />

## 💬 공유사항 to 리뷰어

- `components/common/Tag.tsx`에 태그 컴포넌트를 정의하고, 다음과 같은 속성을 받을 수 있습니다.
   <img width="537" height="505" alt="image" src="https://github.com/user-attachments/assets/c7f892c9-03cc-4048-b7d7-f60fa5ee447e" />

- `constrants/Tag.style.ts`에 태그 색상에 관한 상수 객체를 매핑했습니다.
   <img width="453" height="243" alt="image" src="https://github.com/user-attachments/assets/cc34500a-3914-4e7c-82e4-d86a834d6360" />


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
