### PR TITLE
[feat/#53] - interview Rooms 페이지 선택 모드 구현 및 목업 데이터 연결

### DIFF
--- a/app/interview/rooms/page.tsx
+++ b/app/interview/rooms/page.tsx
@@ -1,8 +1,4 @@
-import HeaderTitleBox from '@/components/common/HeaderTitleBox';
-import { Button } from '@/components/ui/button/Button';
-import { FolderClock } from 'lucide-react';
-import InterviewRoomsList from '@/features/interview/components/InterviewRoomsList';
-import Tags from '@/components/common/Tags/Tags';
+import InterviewManagementContainer from '@/features/interview/components/InterviewManagementContainer';
 
 export const metadata = {
   title: '지난 면접 불러오기',
@@ -11,34 +7,7 @@ export const metadata = {
 const InterviewRoomsPage = () => {
   return (
     <main className="flex flex-col gap-7">
-      <article className="flex justify-between">
-        <HeaderTitleBox
-          title={'지난 면접 불러오기'}
-          content={'이전에 진행했던 면접을 다시 진행해보세요'}
-          icon={FolderClock}
-        />
-
-        <Button variant={'default'}>삭제하기</Button>
-      </article>
-
-      <InterviewRoomsList />
-
-      <div className="flex gap-4">
-        {/* Green */}
-        <Tags size="big">답변 완료</Tags>
-        <Tags size="big">합격</Tags>
-
-        {/* Red */}
-        <Tags size="big">미완료</Tags>
-        <Tags size="big">불합격</Tags>
-
-        {/* Yello */}
-        <Tags size="big">진행중</Tags>
-        <Tags size="big">답변 대기</Tags>
-
-        {/* Purple */}
-        <Tags size="big">기타태그</Tags>
-      </div>
+      <InterviewManagementContainer />
     </main>
   );
 };

--- a/components/common/AiRoomCard.tsx
+++ b/components/common/AiRoomCard.tsx
@@ -4,34 +4,79 @@ import Tags from '@/components/common/Tags/Tags';
 import { Dot } from 'lucide-react';
 import Link from 'next/link';
 import aiRoomsData from '@/data/aiRoomsData.json';
+import { SetStateAction, useState } from 'react';
+import { cn } from '@/lib/utils';
+import SelectCountBox from './SelectCountBox/SelectCountBox';
 
-const AiRoomCard = () => {
+interface AiRoomCardProps {
+  isEditMode: boolean;
+  setIsEditMode: React.Dispatch<SetStateAction<boolean>>;
+}
+
+const AiRoomCard = ({ isEditMode, setIsEditMode }: AiRoomCardProps) => {
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const toggleSelect = (id: number) => {
+    setSelectedIds((prev) =>
+      prev.includes(id)
+        ? prev.filter((itemId) => itemId !== id)
+        : [...prev, id],
+    );
+  };
   return (
     <>
+      {isEditMode === false ? null : (
+        <SelectCountBox
+          setIsEditMode={setIsEditMode}
+          setSelectedIds={setSelectedIds}
+          state="delete"
+          count={selectedIds.length}
+        />
+      )}
+
       {aiRoomsData.map(
-        ({ id, title, createdAt, questionCnt, tags, roomId }) => (
-          <Link key={id} href={`/interview/rooms/${roomId}`}>
-            <article className="card-col">
-              <div className="flex flex-wrap">
-                {tags.map(({ label }) => (
-                  <Tags key={label} className="mr-1" color="green" size="big">
-                    {label}
-                  </Tags>
-                ))}
-              </div>
+        ({ id, title, createdAt, questionCnt, tags, roomId }) => {
+          const isCurrentSelected = selectedIds.includes(id);
 
-              <h6>{title}</h6>
-
-              <div className="text-icon-default c2 flex items-center justify-between">
-                <div className="flex gap-2">
-                  <time className="">생성일: {createdAt}</time>
-                  <Dot size={15} />
-                  <p>질문 {questionCnt}개</p>
+          return (
+            <Link
+              key={id}
+              href={`/interview/rooms/${roomId}`}
+              onClick={(e) => {
+                if (isEditMode) {
+                  e.preventDefault();
+                  toggleSelect(id);
+                }
+              }}
+            >
+              <article
+                className={cn(
+                  'card-col',
+                  isEditMode && isCurrentSelected
+                    ? 'border-tag-text-red/30 bg-tag-bg-red/30'
+                    : '',
+                )}
+              >
+                <div className="flex flex-wrap">
+                  {tags.map(({ label }) => (
+                    <Tags key={label} className="mr-1" color="green" size="big">
+                      {label}
+                    </Tags>
+                  ))}
                 </div>
-              </div>
-            </article>
-          </Link>
-        ),
+
+                <h6 className="h6">{title}</h6>
+
+                <div className="text-icon-default c2 flex items-center justify-between">
+                  <div className="flex gap-2">
+                    <time className="">생성일: {createdAt}</time>
+                    <Dot size={15} />
+                    <p>질문 {questionCnt}개</p>
+                  </div>
+                </div>
+              </article>
+            </Link>
+          );
+        },
       )}
     </>
   );

--- a/components/common/SelectCountBox/SelectCountBox.tsx
+++ b/components/common/SelectCountBox/SelectCountBox.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@/components/ui/button/Button';
 import { cn } from '@/lib/utils';
+import { SetStateAction } from 'react';
 import { toast } from 'sonner';
 
 type State = 'save' | 'delete';
@@ -11,17 +12,29 @@ interface SelectCountBoxProps {
   name?: string;
   onClick?: () => void;
   state: State;
+  setIsEditMode: React.Dispatch<SetStateAction<boolean>>;
+  setSelectedIds: React.Dispatch<SetStateAction<number[]>>;
 }
 
-const SelectCountBox = ({ count, name, state }: SelectCountBoxProps) => {
+const SelectCountBox = ({
+  count,
+  name,
+  state,
+  setIsEditMode,
+  setSelectedIds,
+}: SelectCountBoxProps) => {
   const isSave = state === 'save';
 
   const onClickSaveButtonHandler = () => {
     toast.success('마이페이지에 저장되었습니다!', { position: 'top-center' });
+    setIsEditMode(false);
+    setSelectedIds([]);
   };
 
   const onClickDeleteButtonHandler = () => {
     toast.success('삭제되었습니다.', { position: 'top-center' });
+    setIsEditMode(false);
+    setSelectedIds([]);
   };
   return (
     <>

--- a/data/aiRoomsData.json
+++ b/data/aiRoomsData.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "1",
+    "id": 1,
     "tags": [{ "label": "답변 완료" }, { "label": "FrontEnd" }],
     "title": "JVM의 구조와 Java의 실행방식을 설명해주세요.",
     "createdAt": "2026-01-04",
@@ -8,7 +8,7 @@
     "roomId": 1
   },
   {
-    "id": "2",
+    "id": 2,
     "tags": [
       { "label": "미완료" },
       { "label": "FrontEnd" },

--- a/features/interview/components/InterviewManagementContainer.tsx
+++ b/features/interview/components/InterviewManagementContainer.tsx
@@ -1,0 +1,36 @@
+'use client';
+import HeaderTitleBox from '@/components/common/HeaderTitleBox';
+import { Button } from '@/components/ui/button/Button';
+import { FolderClock } from 'lucide-react';
+import InterviewRoomsList from '@/features/interview/components/InterviewRoomsList';
+import { useState } from 'react';
+
+const InterviewManagementContainer = () => {
+  const [isEditMode, setIsEditMode] = useState(false);
+
+  const handleDeleteButton = () => {
+    setIsEditMode(!isEditMode);
+  };
+
+  return (
+    <>
+      <article className="flex justify-between">
+        <HeaderTitleBox
+          title={'지난 면접 불러오기'}
+          content={'이전에 진행했던 면접을 다시 진행해보세요'}
+          icon={FolderClock}
+        />
+
+        <Button variant={'default'} onClick={handleDeleteButton}>
+          {isEditMode ? <p>삭제 취소</p> : <p>삭제하기</p>}
+        </Button>
+      </article>
+      <InterviewRoomsList
+        isEditMode={isEditMode}
+        setIsEditMode={setIsEditMode}
+      />
+    </>
+  );
+};
+
+export default InterviewManagementContainer;

--- a/features/interview/components/InterviewRoomsList.tsx
+++ b/features/interview/components/InterviewRoomsList.tsx
@@ -1,14 +1,19 @@
 import AiRoomCard from '@/components/common/AiRoomCard';
-import SelectCountBox from '@/components/common/SelectCountBox/SelectCountBox';
+import { SetStateAction } from 'react';
 
-const InterviewRoomsList = () => {
+interface interviewRoomListProps {
+  isEditMode: boolean;
+  setIsEditMode: React.Dispatch<SetStateAction<boolean>>;
+}
+
+const InterviewRoomsList = ({
+  isEditMode,
+  setIsEditMode,
+}: interviewRoomListProps) => {
   return (
     <>
-      <article>
-        <SelectCountBox state="delete" count={2} />
-      </article>
       <article className="flex flex-col gap-3">
-        <AiRoomCard />
+        <AiRoomCard isEditMode={isEditMode} setIsEditMode={setIsEditMode} />
       </article>
     </>
   );


### PR DESCRIPTION
## #️⃣ Issue Number

#53 
## 📝 요약(Summary)

interview Rooms 페이지 선택 모드 구현 및 목업 데이터 연결

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

![녹화_2026_01_12_16_30_37_171](https://github.com/user-attachments/assets/8b0ffc49-c55d-4281-be66-87576addc2e7)

## 💬 공유사항 to 리뷰어

현재 구조에서 선택 모드 진입 및 항목 선택 기능을 위한 상태 관리 로직이 필요해보임
페이지에서 쓰일 공통 기능인 만큼, 다른 페이지들을 수정하기 전에 먼저 구조화 해 두는 게 좋을 것 같다는 생각

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
